### PR TITLE
Keycloaklocal

### DIFF
--- a/k8s/overlays/nerc-shift-1/keycloak-idp-cilogon.yaml
+++ b/k8s/overlays/nerc-shift-1/keycloak-idp-cilogon.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: keycloak-cilogon-idp-secret
+  namespace: keycloak
+spec:
+  target:
+    name: keycloak-cilogon-idp-secret
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  dataFrom:
+    - key: keycloak/idp/cilogon

--- a/k8s/overlays/nerc-shift-1/keycloakrealm.yaml
+++ b/k8s/overlays/nerc-shift-1/keycloakrealm.yaml
@@ -212,7 +212,7 @@ spec:
     - alias: cilogon
       config:
         allowedClockSkew: "5"
-        authorizationUrl: https://cilogon.org/authorize
+        authorizationUrl: https://cilogon.org/authorize?idphint=urn%3Amace%3Aincommon%3Amit.edu,https%3A%2F%2Ffed.huit.harvard.edu%2Fidp%2Fshibboleth,https%3A%2F%2Fshib.bu.edu%2Fidp%2Fshibboleth
         clientAuthMethod: client_secret_post
         clientId: "cilogon:/client_id/ab05912d88d9f9cc5ea155accf420f3"
         clientSecret: ${vault.cilogon_client_secret}  # pragma: allowlist secret

--- a/k8s/overlays/nerc-shift-1/keycloakrealm.yaml
+++ b/k8s/overlays/nerc-shift-1/keycloakrealm.yaml
@@ -36,102 +36,6 @@ spec:
         tls.client.certificate.bound.access.tokens: "false"
         use.refresh.tokens: "true"
       clientAuthenticatorType: client-secret
-      clientId: CHANGEME
-      defaultClientScopes:
-      - web-origins
-      - roles
-      - profile
-      - email
-      directAccessGrantsEnabled: true
-      enabled: true
-      fullScopeAllowed: true
-      implicitFlowEnabled: false
-      nodeReRegistrationTimeout: -1
-      optionalClientScopes:
-      - address
-      - phone
-      - offline_access
-      - microprofile-jwt
-      protocol: openid-connect
-      protocolMappers:
-      - config:
-          access.token.claim: "false"
-          claim.name: cilogon_idp_name
-          id.token.claim: "true"
-          jsonType.label: String
-          user.attribute: cilogon_idp_name
-          userinfo.token.claim: "true"
-        name: cilogon_idp_name
-        protocol: openid-connect
-        protocolMapper: oidc-usermodel-attribute-mapper
-      - config:
-          access.token.claim: "false"
-          claim.name: preferred_username
-          id.token.claim: "true"
-          jsonType.label: String
-          user.attribute: username
-          userinfo.token.claim: "true"
-        name: username
-        protocol: openid-connect
-        protocolMapper: oidc-usermodel-property-mapper
-      - config:
-          access.token.claim: "true"
-          claim.name: clientHost
-          id.token.claim: "true"
-          jsonType.label: String
-          user.session.note: clientHost
-        name: Client Host
-        protocol: openid-connect
-        protocolMapper: oidc-usersessionmodel-note-mapper
-      - config:
-          access.token.claim: "true"
-          claim.name: clientAddress
-          id.token.claim: "true"
-          jsonType.label: String
-          user.session.note: clientAddress
-        name: Client IP Address
-        protocol: openid-connect
-        protocolMapper: oidc-usersessionmodel-note-mapper
-      - config:
-          access.token.claim: "true"
-          claim.name: clientId
-          id.token.claim: "true"
-          jsonType.label: String
-          user.session.note: clientId
-        name: Client ID
-        protocol: openid-connect
-        protocolMapper: oidc-usersessionmodel-note-mapper
-      publicClient: false
-      redirectUris:
-      - https://regapp.mss.mghpcc.org/*
-      secret: CHANGEME
-      serviceAccountsEnabled: true
-      standardFlowEnabled: true
-    - attributes:
-        access.token.lifespan: "60"
-        backchannel.logout.revoke.offline.tokens: "false"
-        backchannel.logout.session.required: "true"
-        client_credentials.use_refresh_token: "false"
-        display.on.consent.screen: "false"
-        exclude.session.state.from.auth.response: "false"
-        id.token.as.detached.signature: "false"
-        oauth2.device.authorization.grant.enabled: "false"
-        oidc.ciba.grant.enabled: "false"
-        require.pushed.authorization.requests: "false"
-        saml.artifact.binding: "false"
-        saml.assertion.signature: "false"
-        saml.authnstatement: "false"
-        saml.client.signature: "false"
-        saml.encrypt: "false"
-        saml.force.post.binding: "false"
-        saml.multivalued.roles: "false"
-        saml.onetimeuse.condition: "false"
-        saml.server.signature: "false"
-        saml.server.signature.keyinfo.ext: "false"
-        saml_force_name_id_format: "false"
-        tls.client.certificate.bound.access.tokens: "false"
-        use.refresh.tokens: "true"
-      clientAuthenticatorType: client-secret
       clientId: CHANGEME2
       defaultClientScopes:
       - web-origins
@@ -310,8 +214,8 @@ spec:
         allowedClockSkew: "5"
         authorizationUrl: https://cilogon.org/authorize
         clientAuthMethod: client_secret_post
-        clientId: CHANGEME
-        clientSecret: CHANGEME
+        clientId: "cilogon:/client_id/ab05912d88d9f9cc5ea155accf420f3"
+        clientSecret: ${vault.cilogon_client_secret}  # pragma: allowlist secret
         defaultScope: openid email profile org.cilogon.userinfo
         syncMode: IMPORT
         tokenUrl: https://cilogon.org/oauth2/token

--- a/k8s/overlays/nerc-shift-1/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/kustomization.yaml
@@ -3,8 +3,18 @@ resources:
   - ha-postgres.yaml
   - ../../base
   - keycloakrealm.yaml
+  - regapp-client.yaml
   - keycloak-tls-secret.yaml
+  - keycloak-idp-cilogon.yaml
   - ingress.yaml
 
 patchesStrategicMerge:
   - patches/keycloak.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+  
+configMapGenerator:
+  - name: regapp-client-script
+    files:
+    - regapp-client-script.sh

--- a/k8s/overlays/nerc-shift-1/patches/keycloak.yaml
+++ b/k8s/overlays/nerc-shift-1/patches/keycloak.yaml
@@ -10,6 +10,16 @@ spec:
   keycloakDeploymentSpec:
     experimental:
       env:
+        - name: CILOGON_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              key: CLIENT_ID
+              name: keycloak-cilogon-idp-secret
+        - name: CILOGON_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: CLIENT_SECRET
+              name: keycloak-cilogon-idp-secret
         - name: DB_ADDR
           valueFrom:
             secretKeyRef:
@@ -35,6 +45,26 @@ spec:
             secretKeyRef:
               name: mss-keycloak-pgha-pguser-mss-keycloak-pgha
               key: password
+      volumes:
+        defaultMode: 0777
+        items:
+          # - name: cilogon-idp-secret
+          #   secrets:
+          #     - keycloak-cilogon-idp-secret
+          #   # $JBOSS_HOME/secrets - supported by kc container
+          #   # reference in keycloak as ${vault.cilogon_client_secret}
+          #   mountPath: /opt/jboss/keycloak/secrets
+          #   items:
+          #     - key: CLIENT_SECRET
+          #       path: mss_cilogon__client__secret
+          - name: regapp-client-script
+            configMaps:
+              - regapp-client-script
+            mountPath: /opt/jboss/startup-scripts
+            items:
+              - key: regapp-client-script.sh
+                path: regapp-client-script.sh
+                mode: 0777
   externalDatabase:
     enabled: true
   externalAccess:

--- a/k8s/overlays/nerc-shift-1/regapp-client-script.sh
+++ b/k8s/overlays/nerc-shift-1/regapp-client-script.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+CLI=/opt/jboss/keycloak/bin/kcadm.sh
+REGAPP_CLIENT_ID=regapp
+IDP_MAPPER_CONFIG='{"identityProviderAlias":"cilogon","config":{"syncMode":"IMPORT","claim":"idp_name","user.attribute":"cilogon_idp_name"},"name":"cilogon_idp_name","identityProviderMapper":"oidc-user-attribute-idp-mapper"}'
+REDIRECTOR_CONFIG='{"config":{"defaultProvider":"cilogon"},"alias":"cilogon_auth_config"}'
+
+# Called on startup with no args, must background self so
+# as not to block startup while wating for startup...
+if [ $# -eq 0 ]; then
+    CMD=$(realpath $0)
+    $CMD foo & disown
+else
+    # Called with an arg, this is the backgrounded invocation
+
+    # Wait until keycloak api is up
+    until $CLI config credentials --server http://localhost:8080/auth --realm master --client admin-cli --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
+    do
+        echo regapp-client-script waiting for server to start...
+        sleep 5
+    done
+
+    # Now wait until realm and client are viable
+    sleep 5
+    until $CLI get realms/mss/clients -q clientId=$REGAPP_CLIENT_ID --fields id --format csv --noquotes
+    do
+        echo regapp-client-script waiting for realm and client to become available...
+        sleep 5
+    done 
+
+    # Add all realm management roles (mappings) to regapp service account
+    sleep 5
+    REGAPP_CLIENT_KCID=$($CLI get realms/mss/clients -q clientId=$REGAPP_CLIENT_ID --fields id --format csv --noquotes)
+    SVC_ACCT_USER_KCID=$($CLI get realms/mss/clients/$REGAPP_CLIENT_KCID/service-account-user --fields id --format csv --noquotes)
+    REALM_MGMT_CLIENT_KCID=$($CLI get realms/mss/clients -q clientId=realm-management --fields id --format csv --noquotes)
+    ALLROLES=$($CLI get realms/mss/clients/$REALM_MGMT_CLIENT_KCID/roles --fields id,name)
+    $CLI create realms/mss/users/$SVC_ACCT_USER_KCID/role-mappings/clients/$REALM_MGMT_CLIENT_KCID --body "$ALLROLES"
+
+    # Add the idp mapper for cilogon
+    $CLI create realms/mss/identity-provider/instances/cilogon/mappers --body $IDP_MAPPER_CONFIG
+
+    # Update cilogon clientId and clientSecret
+    # sed replace needs to be clean of \ / and &
+    CISEC=$(printf '%s\n' "$CILOGON_CLIENT_SECRET" | sed -e 's/[\/&]/\\&/g')
+    CIID=$(printf '%s\n' "$CILOGON_CLIENT_ID" | sed -e 's/[\/&]/\\&/g')
+    CILOGON_IDP_REP=$($CLI get realms/mss/identity-provider/instances/cilogon | sed -e "s/\"clientSecret.*,/\"clientSecret\": \"$CISEC\",/g" -e "s/\"clientId.*,/\"clientId\": \"$CIID\",/g")
+    $CLI update realms/mss/identity-provider/instances/cilogon --body "$CILOGON_IDP_REP"
+
+
+    # Configure the idp redirector execution in the browser flow to go directly
+    # to cilogon
+    REDIRECTOR_KCID=$($CLI get realms/mss/authentication/flows/browser/executions  --format csv --fields id,displayName --noquotes | sed -n 's/\(.*\),Identity Provider Redirector.*/\1/p')
+    $CLI create realms/mss/authentication/executions/$REDIRECTOR_KCID/config --body $REDIRECTOR_CONFIG
+
+    # Example update - note this command cannot change client id!!
+    # $CLI update realms/mss/clients/$REGAPP_CLIENT_ID  -s description=supersuccesssuperdude
+fi

--- a/k8s/overlays/nerc-shift-1/regapp-client-script.sh
+++ b/k8s/overlays/nerc-shift-1/regapp-client-script.sh
@@ -40,6 +40,7 @@ else
 
     # Update cilogon clientId and clientSecret
     # sed replace needs to be clean of \ / and &
+    # jq would be much better but not available in stock image
     CISEC=$(printf '%s\n' "$CILOGON_CLIENT_SECRET" | sed -e 's/[\/&]/\\&/g')
     CIID=$(printf '%s\n' "$CILOGON_CLIENT_ID" | sed -e 's/[\/&]/\\&/g')
     CILOGON_IDP_REP=$($CLI get realms/mss/identity-provider/instances/cilogon | sed -e "s/\"clientSecret.*,/\"clientSecret\": \"$CISEC\",/g" -e "s/\"clientId.*,/\"clientId\": \"$CIID\",/g")
@@ -51,6 +52,6 @@ else
     REDIRECTOR_KCID=$($CLI get realms/mss/authentication/flows/browser/executions  --format csv --fields id,displayName --noquotes | sed -n 's/\(.*\),Identity Provider Redirector.*/\1/p')
     $CLI create realms/mss/authentication/executions/$REDIRECTOR_KCID/config --body $REDIRECTOR_CONFIG
 
-    # Example update - note this command cannot change client id!!
+    # Example update
     # $CLI update realms/mss/clients/$REGAPP_CLIENT_ID  -s description=supersuccesssuperdude
 fi

--- a/k8s/overlays/nerc-shift-1/regapp-client.yaml
+++ b/k8s/overlays/nerc-shift-1/regapp-client.yaml
@@ -1,0 +1,107 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakClient
+metadata:
+  name: regapp-client
+  namespace: regapp
+  labels:
+    client: regapp-client
+spec:
+  realmSelector:
+    matchLabels:
+      realm: mss
+  client:
+    attributes:
+      access.token.lifespan: "60"
+      backchannel.logout.revoke.offline.tokens: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      display.on.consent.screen: "false"
+      exclude.session.state.from.auth.response: "false"
+      id.token.as.detached.signature: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      oidc.ciba.grant.enabled: "false"
+      require.pushed.authorization.requests: "false"
+      saml.artifact.binding: "false"
+      saml.assertion.signature: "false"
+      saml.authnstatement: "false"
+      saml.client.signature: "false"
+      saml.encrypt: "false"
+      saml.force.post.binding: "false"
+      saml.multivalued.roles: "false"
+      saml.onetimeuse.condition: "false"
+      saml.server.signature: "false"
+      saml.server.signature.keyinfo.ext: "false"
+      saml_force_name_id_format: "false"
+      tls.client.certificate.bound.access.tokens: "false"
+      use.refresh.tokens: "true"
+    clientAuthenticatorType: client-secret
+    clientId: regapp
+    defaultClientScopes:
+    - web-origins
+    - roles
+    - profile
+    - email
+    directAccessGrantsEnabled: true
+    enabled: true
+    fullScopeAllowed: true
+    implicitFlowEnabled: false
+    nodeReRegistrationTimeout: -1
+    optionalClientScopes:
+    - address
+    - phone
+    - offline_access
+    - microprofile-jwt
+    protocol: openid-connect
+    protocolMappers:
+    - config:
+        access.token.claim: "false"
+        claim.name: cilogon_idp_name
+        id.token.claim: "true"
+        jsonType.label: String
+        user.attribute: cilogon_idp_name
+        userinfo.token.claim: "true"
+      name: cilogon_idp_name
+      protocol: openid-connect
+      protocolMapper: oidc-usermodel-attribute-mapper
+    - config:
+        access.token.claim: "false"
+        claim.name: preferred_username
+        id.token.claim: "true"
+        jsonType.label: String
+        user.attribute: username
+        userinfo.token.claim: "true"
+      name: username
+      protocol: openid-connect
+      protocolMapper: oidc-usermodel-property-mapper
+    - config:
+        access.token.claim: "true"
+        claim.name: clientHost
+        id.token.claim: "true"
+        jsonType.label: String
+        user.session.note: clientHost
+      name: Client Host
+      protocol: openid-connect
+      protocolMapper: oidc-usersessionmodel-note-mapper
+    - config:
+        access.token.claim: "true"
+        claim.name: clientAddress
+        id.token.claim: "true"
+        jsonType.label: String
+        user.session.note: clientAddress
+      name: Client IP Address
+      protocol: openid-connect
+      protocolMapper: oidc-usersessionmodel-note-mapper
+    - config:
+        access.token.claim: "true"
+        claim.name: clientId
+        id.token.claim: "true"
+        jsonType.label: String
+        user.session.note: clientId
+      name: Client ID
+      protocol: openid-connect
+      protocolMapper: oidc-usersessionmodel-note-mapper
+    publicClient: false
+    redirectUris:
+    - https://regapp.mss.mghpcc.org/*
+    serviceAccountsEnabled: true
+    standardFlowEnabled: true


### PR DESCRIPTION
split client creation out using KeycloakClient crd
created startup script to patch keycloak post-startup with stuff that cannot be set in the realm and client CRDs
tweak to cilogon for keycloak path that limits idp choices to mit, harvard and bu 