### PR TITLE
update keycloak-metrics-spi to 2.5.3

### DIFF
--- a/k8s/base/keycloak.yaml
+++ b/k8s/base/keycloak.yaml
@@ -8,5 +8,5 @@ spec:
     enabled: true
   extensions:
     - >-
-      https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar
+      https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.5.3/keycloak-metrics-spi-2.5.3.jar
   instances: 1


### PR DESCRIPTION
... for compatibility with Keycloak 15+. See:

https://github.com/aerogear/keycloak-metrics-spi/releases/tag/2.5.3