### PR TITLE
Automated and manual backups

### DIFF
--- a/k8s/overlays/nerc-shift-1/ha-postgres.yaml
+++ b/k8s/overlays/nerc-shift-1/ha-postgres.yaml
@@ -30,7 +30,11 @@ spec:
       configuration:
       - secret:
           name: pgo-s3-conf
+      #- secret:
+      #    name: pgo-pgbackrest-secrets
       global:
+        #repo1-cipher-type: aes-256-cbc
+        #repo2-cipher-type: aes-256-cbc
         repo2-path: /pgbackrest/postgres-operator/mss-keycloak-pgha/repo2
         repo2-s3-uri-style: path
       manual:

--- a/k8s/overlays/nerc-shift-1/ha-postgres.yaml
+++ b/k8s/overlays/nerc-shift-1/ha-postgres.yaml
@@ -35,6 +35,9 @@ spec:
         repo2-s3-uri-style: path
       repos:
       - name: repo1
+        schedules:
+          full: "0 1 * * *"
+          incremental: "0 */4 * * *"
         volume:
           volumeClaimSpec:
             accessModes:
@@ -43,6 +46,9 @@ spec:
               requests:
                 storage: 5Gi
       - name: repo2
+        schedules:
+          full: "0 1 * * *"
+          incremental: "0 */4 * * *"
         s3:
           bucket: "nerc-shift-1-backups"
           endpoint: "holecs.rc.fas.harvard.edu"

--- a/k8s/overlays/nerc-shift-1/ha-postgres.yaml
+++ b/k8s/overlays/nerc-shift-1/ha-postgres.yaml
@@ -33,6 +33,10 @@ spec:
       global:
         repo2-path: /pgbackrest/postgres-operator/mss-keycloak-pgha/repo2
         repo2-s3-uri-style: path
+      manual:
+        repoName: repo2
+        options:
+         - --type=full
       repos:
       - name: repo1
         schedules:

--- a/k8s/overlays/nerc-shift-1/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/kustomization.yaml
@@ -1,6 +1,7 @@
 namespace: keycloak
 resources:
   - secrets/pgo-s3-conf.yaml
+  - secrets/pgo-pgbackrest-secrets.yaml
   - ha-postgres.yaml
   - ../../base
   - keycloakrealm.yaml

--- a/k8s/overlays/nerc-shift-1/secrets/pgo-pgbackrest-secrets.yaml
+++ b/k8s/overlays/nerc-shift-1/secrets/pgo-pgbackrest-secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: pgo-pgbackrest-secrets
+spec:
+  target:
+    name: pgo-pgbackrest-secrets
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  dataFrom:
+    - key: pgbackrest/mss-keycloak-pgha/cipher


### PR DESCRIPTION
- 1 full backup at 1am
- incremental backups every 4hr
- add support for manual backups to s3 via postgrescluster annotations (see https://access.crunchydata.com/documentation/postgres-operator/v5/tutorial/backup-management/#taking-a-one-off-backup)
- staged client-side encryption config (commented/disabled for now - requires rebuild or maintenance window)