### PR TITLE
added research domain attribute mapper to regapp client

### DIFF
--- a/k8s/overlays/nerc-shift-1/clients/regapp.yaml
+++ b/k8s/overlays/nerc-shift-1/clients/regapp.yaml
@@ -74,6 +74,16 @@ spec:
       protocolMapper: oidc-usermodel-property-mapper
     - config:
         access.token.claim: "true"
+        claim.name: mss_research_domain
+        id.token.claim: "true"
+        jsonType.label: String
+        user.attribute: mss_research_domain
+        userinfo.token.claim: "true"
+      name: mss_research_domain
+      protocol: openid-connect
+      protocolMapper: oidc-usermodel-attribute-mapper
+    - config:
+        access.token.claim: "true"
         claim.name: clientHost
         id.token.claim: "true"
         jsonType.label: String


### PR DESCRIPTION
There was a missing mapper for the domain of science attribute so the regapp "manage my account" for was showing "other" all the time