### PR TITLE
add staging to coldfront client redirectUris list

### DIFF
--- a/k8s/overlays/nerc-shift-1/clients/coldfront.yaml
+++ b/k8s/overlays/nerc-shift-1/clients/coldfront.yaml
@@ -142,5 +142,6 @@ spec:
     publicClient: false
     redirectUris:
     - https://coldfront.mss.mghpcc.org/*
+    - https://coldfront-staging.mss.mghpcc.org/*
     serviceAccountsEnabled: true
     standardFlowEnabled: true


### PR DESCRIPTION
This allows us to use the same keycloak client for a new coldfront staging environment. See https://github.com/nerc-project/coldfront-nerc/pull/74