### PR TITLE
Add missing client for ai-telemetry with new redirectUri

### DIFF
--- a/k8s/overlays/nerc-shift-1/clients/ai-telemetry.yaml
+++ b/k8s/overlays/nerc-shift-1/clients/ai-telemetry.yaml
@@ -1,0 +1,101 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakClient
+metadata:
+  name: ai-telemetry
+  labels:
+    client: ai-telemetry
+spec:
+  realmSelector:
+    matchLabels:
+      realm: mss
+  client:
+    clientId: ai-telemetry
+    name: ""
+    description: ""
+    rootUrl: ""
+    adminUrl: ""
+    baseUrl: ""
+    surrogateAuthRequired: false
+    enabled: true
+    alwaysDisplayInConsole: false
+    clientAuthenticatorType: client-secret
+    redirectUris:
+    - https://keycloak.apps.obs.nerc.mghpcc.org/realms/NERC/broker/keycloak-oidc/endpoint
+    webOrigins: []
+    notBefore: 0
+    bearerOnly: false
+    consentRequired: false
+    standardFlowEnabled: true
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    serviceAccountsEnabled: true
+    publicClient: false
+    frontchannelLogout: true
+    protocol: openid-connect
+    attributes:
+      oidc.ciba.grant.enabled: "false"
+      client.secret.creation.time: "1739990732"
+      backchannel.logout.session.required: "true"
+      oauth2.device.authorization.grant.enabled: "false"
+      display.on.consent.screen: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+    authenticationFlowBindingOverrides: {}
+    fullScopeAllowed: true
+    nodeReRegistrationTimeout: -1
+    protocolMappers:
+      - name: username
+        protocol: openid-connect
+        protocolMapper: oidc-usermodel-property-mapper
+        consentRequired: false
+        config:
+          userinfo.token.claim: "true"
+          user.attribute: username
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: uid
+          jsonType.label: String
+      - name: Client Host
+        protocol: openid-connect
+        protocolMapper: oidc-usersessionmodel-note-mapper
+        consentRequired: false
+        config:
+          user.session.note: clientHost
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: clientHost
+          jsonType.label: String
+      - name: Client IP Address
+        protocol: openid-connect
+        protocolMapper: oidc-usersessionmodel-note-mapper
+        consentRequired: false
+        config:
+          user.session.note: clientAddress
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: clientAddress
+          jsonType.label: String
+      - name: Client ID
+        protocol: openid-connect
+        protocolMapper: oidc-usersessionmodel-note-mapper
+        consentRequired: false
+        config:
+          user.session.note: clientId
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: clientId
+          jsonType.label: String
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - email
+    optionalClientScopes:
+      - address
+      - phone
+      - offline_access
+      - microprofile-jwt
+    access:
+      view: true
+      configure: true
+      manage: true

--- a/k8s/overlays/nerc-shift-1/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - clients/rhoai-test.yaml
   - clients/ocp-virt.yaml
   - clients/ocp-edu.yaml
+  - clients/ai-telemetry.yaml
   - keycloak-idp-cilogon.yaml
   - ingress.yaml
 


### PR DESCRIPTION
## Motivation
Closes #nerc-project/operations/issues/1395

Integration of AI Telemetry authentication with the MOC Keycloak realm of users so that NAIRR projects, research projects, university projects, and operation teams can view metrics at the Tenant, Hub, Cluster, or Project level. This has also become a priority for Innabox as a UI that calls the fulfillment API in the hypershift1 and hypershift2 cluster. 

We need to add this redirect URI to the ai-telemetry client in the MOC Keycloak. 

Redirect URI: https://keycloak.apps.obs.nerc.mghpcc.org/realms/NERC/broker/keycloak-oidc/endpoint

This will allow users to authenticate to AI Telemetry to observe their project/cluster/hub metrics with their MOC account from here:

https://aitelemetry.apps.obs.nerc.mghpcc.org/
