### PR TITLE
Adding AI Telemetry logout redirectUri to ai-telemetry

### DIFF
--- a/k8s/overlays/nerc-shift-1/clients/ai-telemetry.yaml
+++ b/k8s/overlays/nerc-shift-1/clients/ai-telemetry.yaml
@@ -21,6 +21,7 @@ spec:
     clientAuthenticatorType: client-secret
     redirectUris:
     - https://keycloak.apps.obs.nerc.mghpcc.org/realms/NERC/broker/keycloak-oidc/endpoint
+    - https://keycloak.apps.obs.nerc.mghpcc.org/realms/NERC/broker/keycloak-oidc/endpoint/logout_response
     webOrigins: []
     notBefore: 0
     bearerOnly: false


### PR DESCRIPTION
- **Adding AI Telemetry logout redirectUri to ai-telemetry**

For users to logout of AI Telemetry from mss-keycloak, the ai-telemetry client needs the logout_response added to the redirectUris.

<img width="500" height="244" alt="image" src="https://github.com/user-attachments/assets/67ebebf5-aaf6-473c-a3cc-6d8fb7ac810b" />
